### PR TITLE
Fix httpGet error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func fetchBudgets(cfg Config) ([]Budget, error) {
 }
 
 // httpGet performs a GET request with bearer token and returns response body
-func httpGet(client *http.Client, url, token string) ([]byte, error) {
+func httpGet(client *http.Client, url, token string) (data []byte, err error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -126,9 +126,11 @@ func httpGet(client *http.Client, url, token string) ([]byte, error) {
 		err = errors.Join(err, resp.Body.Close())
 	}()
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bad status: %d", resp.StatusCode)
+		err = fmt.Errorf("bad status: %d", resp.StatusCode)
+		return
 	}
-	return io.ReadAll(resp.Body)
+	data, err = io.ReadAll(resp.Body)
+	return
 }
 
 // decodeBudgets decodes a budgets list JSON

--- a/new_test.go
+++ b/new_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type errorBody struct{ io.Reader }
+
+func (e *errorBody) Close() error { return errors.New("close error") }
+
+type staticRoundTripper struct{}
+
+func (staticRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       &errorBody{Reader: strings.NewReader("data")},
+	}, nil
+}
+
+func TestHttpGetCloseError(t *testing.T) {
+	client := &http.Client{Transport: staticRoundTripper{}}
+	_, err := httpGet(client, "http://example", "tok")
+	if err == nil || !strings.Contains(err.Error(), "close error") {
+		t.Fatalf("expected close error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- propagate errors from resp.Body.Close
- add regression test for httpGet close failure

## Testing
- `go test ./...`
- `go test -run HttpGetCloseError -v`

------
https://chatgpt.com/codex/tasks/task_e_6867db092b94832e8302a2493598ed2d